### PR TITLE
Fix diff error when answer path contains spaces

### DIFF
--- a/local_judge/judge.py
+++ b/local_judge/judge.py
@@ -233,6 +233,7 @@ class LocalJudge:
             return False, "no_answer_file"
         # Sync the file mode
         copymode(answer_filepath, output_filepath)
+        answer_filepath = '"{}"'.format(answer_filepath)
         cmd = re.sub(r"{output}", output_filepath, self.diff_command)
         cmd = re.sub(r"{answer}", answer_filepath, cmd)
         process = Popen(


### PR DESCRIPTION
In judge.py, `answer_path` is expanded to an absolute path. If this path contains spaces, the diff command may fail with the following error:

```
local-judge: v2.7.2
2025-02-18 06:28:18,485 [ERROR] Failed in compare stage. Error message:

diff: extra operand '../output/2local_1739831298.out' diff: Try 'diff --help' for more information.
```

This commit wraps `answer_path` in double quotes to prevent diff from treating spaces as separators.